### PR TITLE
openshift: remove oc rsync options

### DIFF
--- a/playbooks/openshift/unprivileged-machine.yaml
+++ b/playbooks/openshift/unprivileged-machine.yaml
@@ -27,4 +27,4 @@
       command: "oc exec {{ zuul_resources['pod'].pod }} mkdir src"
 
     - name: Copy src repos to the pod
-      command: "oc rsync --strategy=tar {{ zuul.executor.src_root }}/ {{ zuul_resources['pod'].pod }}:src/"
+      command: "oc rsync -q --progress=false {{ zuul.executor.src_root }}/ {{ zuul_resources['pod'].pod }}:src/"


### PR DESCRIPTION
It seems like oc rsync output is starving zuul-executor console stream
stdout buffer and makes the command stall.
It seems like the job works much better in quiet mode.