### PR TITLE
base-openshift-pod: use logclassify_ara_database

### DIFF
--- a/roles/log-classify/defaults/main.yaml
+++ b/roles/log-classify/defaults/main.yaml
@@ -27,6 +27,8 @@ logclassify_model_dir: "{{ logclassify_tmp_dir }}"
 
 # Process console-log
 logclassify_console: true
+# Process ara ansible.sqlite
+logclassify_ara_database: false
 
 # Include paths from baseline logs
 logclassify_logserver_dir: ""

--- a/roles/log-classify/tasks/run.yaml
+++ b/roles/log-classify/tasks/run.yaml
@@ -49,6 +49,7 @@
       {% if logclassify_model_pipeline %}--pipeline {{ logclassify_model_pipeline }}{% endif %}
       --count {{ logclassify_model_job_count }}
       --zuul-web {{ logclassify_zuul_web }}
+      {% if logclassify_ara_database %}--ara-database {% endif %}
       {% if logclassify_logserver_dir %}--include-path {{ logclassify_logserver_dir }}{% endif %}
       {% for _path in logclassify_exclude_paths %}--exclude-path {{ _path }}{% endfor %}
       {% for _path in logclassify_exclude_files %}--exclude-file {{ _path }}{% endfor %}
@@ -73,16 +74,19 @@
       --after-context {{ logclassify_after_context }}
       {% if logclassify_local_dir != zuul.executor.log_root %}
         {# Running on test instance directly #}
-        {% if logclassify_console %}
-            {{ logclassify_tmp_dir }}/job-output.txt
-        {% endif %}
-        {% if logclassify_local_dir %}
+        {% if logclassify_ara_database %}
+            {{ logclassify_tmp_dir }}/ara-report/ansible.sqlite
+        {% elif logclassify_local_dir %}
             {{ logclassify_local_dir }}
             --test-prefix {{ logclassify_logserver_dir }}
+        {% else %}
+            {{ logclassify_tmp_dir }}/job-output.txt
         {% endif %}
       {% else %}
         {# Running on executor #}
-        {% if logclassify_logserver_dir %}
+        {% if logclassify_ara_database %}
+            {{ logclassify_local_dir }}/ara-report/ansible.sqlite
+        {% elif logclassify_logserver_dir %}
             {{ logclassify_local_dir }}
         {% else %}
             {{ logclassify_local_dir }}/job-output.txt

--- a/zuul.d/_jobs-openshift.yaml
+++ b/zuul.d/_jobs-openshift.yaml
@@ -42,6 +42,8 @@
     secrets:
       - site_sflogs
     timeout: 1800
+    vars:
+      logclassify_ara_database: true
     nodeset:
       nodes:
         - name: pod


### PR DESCRIPTION
This change uses the new --ara-database logreduce options added in version
0.3.0. Run yum update -y rh-python35-logreduce before using this.