### PR TITLE
bumped openshift job retry attempt count from 1 to 3

### DIFF
--- a/zuul.d/_jobs-openshift.yaml
+++ b/zuul.d/_jobs-openshift.yaml
@@ -37,8 +37,7 @@
     roles:
       - zuul: thoth-station/zuul-test-jobs
       - zuul: zuul-jobs
-    # Set attempts to 1 until it's working well
-    attempts: 1
+    attempts: 3
     secrets:
       - site_sflogs
     timeout: 1800


### PR DESCRIPTION
This should mitigate RETRY_LIMIT issues happening when pod aren't
fully ready or usable.