### PR TITLE
update build-trigger playbook to use parameter input

### DIFF
--- a/playbooks/thoth-openshift-trigger-build/run.yaml
+++ b/playbooks/thoth-openshift-trigger-build/run.yaml
@@ -12,3 +12,29 @@
         follow_redirects: all
         headers:
           Content-Type: "application/json"
+      when: webhook_url is defined
+
+    - name: "Trigger OpenShift Build"
+      uri:
+        method: POST
+        url: "https://{{ cluster }}/oapi/v1/namespaces/{{ namespace }}/buildconfigs/{{ buildConfigName }}/webhooks/{{ webhook_secret.key }}/generic"
+        body_format: json
+        content: ""
+        validate_certs: no
+        follow_redirects: all
+        headers:
+          Content-Type: "application/json"
+      when: 
+        - cluster is defined
+        - namespace is defined
+        - buildConfigName is defined
+
+    - name: "Show error message if no build is trigger"
+      debug:
+        msg: 
+          - "No OpenShift Build is triggered, please provide either of the following parameter set" 
+          - "(webhook_url, webhook_secret)"
+          - "(cluster, namespace, buildConfigName, webhook_secret)"
+      when:
+          - webhook_url is not defined
+          - (cluster is not defined) or (namespace is not defined) or (buildConfigName is not defined)


### PR DESCRIPTION
For the new ansible task that triggers the OpenShift build, it contains two tasks with it. One is supporting the old implementation and the other one is supporting the new implementation. 

The old implementation supporting two parameters:
- webhook_url
- webhook_secret.key

This new implementation supporting four parameters;
- cluster
- namespace
- buildConfigName
- webhook_secret.key

Depends on the given parameter, only one task is executed and the other one would be skipped based on the when condition. Now both are supported for back compatibility. The new implementation is suggested to comply with.

Add an error message if none of the jobs is triggered, which is when `webhook_url` is not provided for the first job and one or more of `cluster`, `namespace`, `buildConfigName` parameter is missing for the second job.

Welcome for comment or suggestion for this updated implementation.