### PR TITLE
Revert "preparing migration to thoth-zuul-psi"

### DIFF
--- a/nodepool/thoth.yaml
+++ b/nodepool/thoth.yaml
@@ -16,38 +16,19 @@
       pools:
         - name: "thoth-zuul"
           labels:
-            - name: "thoth-coala-upshift"
+            - name: "thoth-coala"
               image: "thoth-coala:latest"
               cpu: 1
               memory: 1024
-            - name: "thoth-pylint-upshift"
+            - name: "thoth-pylint"
               image: "thoth-pylint:latest"
               cpu: 1
               memory: 1024
-            - name: "thoth-pytest-upshift"
+            - name: "thoth-pytest"
               image: "thoth-pytest:latest"
               cpu: 2
               memory: 1024
-
-    - name: "thoth-zuul-psi"
-      driver: openshiftpods
-      context: "thoth-zuul/paas-psi-redhat-com:443/system:serviceaccount:thoth-zuul:nodepool"
-      pools:
-        - name: "thoth-zuul"
-          labels:
-            - name: "thoth-coala"
-              image: "thoth-coala:ubi8"
-              cpu: 1
-              memory: 1024
-            - name: "thoth-pylint"
-              image: "thoth-pylint:ubi8"
-              cpu: 1
-              memory: 1024
-            - name: "thoth-pytest"
-              image: "thoth-pytest:ubi8"
-              cpu: 2
-              memory: 1024
             - name: "thoth-ops"
-              image: "thoth-ops:v0.10.1"
+              image: "thoth-ops:latest"
               cpu: 1
-              memory: 512
+              memory: 1024


### PR DESCRIPTION
Reverts thoth-station/zuul-config#55

This has a broken config (labels are missing).