### PR TITLE
Update trigger build job with a default cluster parameter

### DIFF
--- a/playbooks/thoth-openshift-trigger-build/run.yaml
+++ b/playbooks/thoth-openshift-trigger-build/run.yaml
@@ -1,6 +1,9 @@
 ---
 - hosts: all
 
+  vars:
+    cluster: "paas.psi.redhat.com"
+
   tasks:
     - name: "Trigger OpenShift Build"
       uri:
@@ -37,4 +40,4 @@
           - "(cluster, namespace, buildConfigName, webhook_secret)"
       when:
           - webhook_url is not defined
-          - (cluster is not defined) or (namespace is not defined) or (buildConfigName is not defined)
+          - (namespace is not defined) or (buildConfigName is not defined)


### PR DESCRIPTION
Set the default value of cluster to paas.upshift.redhat.com, which becomes a not required parameter for the trigger build job.