### PR TITLE
Fix the Ansible playbook for getting bad request error

### DIFF
--- a/playbooks/thoth-openshift-trigger-build/run.yaml
+++ b/playbooks/thoth-openshift-trigger-build/run.yaml
@@ -9,8 +9,6 @@
       uri:
         method: POST
         url: "{{ webhook_url }}/webhooks/{{ webhook_secret.key }}/generic"
-        body_format: json
-        content: ""
         validate_certs: no
         follow_redirects: all
         headers:
@@ -21,8 +19,6 @@
       uri:
         method: POST
         url: "https://{{ cluster }}/oapi/v1/namespaces/{{ namespace }}/buildconfigs/{{ buildConfigName }}/webhooks/{{ webhook_secret.key }}/generic"
-        body_format: json
-        content: ""
         validate_certs: no
         follow_redirects: all
         headers:


### PR DESCRIPTION
Remove the job body and its content, tested it locally, which doesn't give "expected pointer, but got nil" error after send out the webhook.