### PR TITLE
[WIP] Add push new build image to quay.io feature

### DIFF
--- a/playbooks/thoth-openshift-trigger-build/run.yaml
+++ b/playbooks/thoth-openshift-trigger-build/run.yaml
@@ -2,20 +2,12 @@
 - hosts: all
 
   vars:
-    cluster: "paas.psi.redhat.com"
+    - thoth_ops_version: "v0.10.0"
+    - cluster: "paas.psi.redhat.com"
+    - image_stream_tag: "test"
 
   tasks:
-    - name: "Trigger OpenShift Build"
-      uri:
-        method: POST
-        url: "{{ webhook_url }}/webhooks/{{ webhook_secret.key }}/generic"
-        validate_certs: no
-        follow_redirects: all
-        headers:
-          Content-Type: "application/json"
-      when: webhook_url is defined
-
-    - name: "Trigger OpenShift Build"
+   - name: "Trigger OpenShift Build"
       uri:
         method: POST
         url: "https://{{ cluster }}/oapi/v1/namespaces/{{ namespace }}/buildconfigs/{{ buildConfigName }}/webhooks/{{ webhook_secret.key }}/generic"
@@ -23,17 +15,127 @@
         follow_redirects: all
         headers:
           Content-Type: "application/json"
-      when: 
+      register: response_content
+      when:
         - cluster is defined
         - namespace is defined
         - buildConfigName is defined
 
     - name: "Show error message if no build is trigger"
       debug:
-        msg: 
-          - "No OpenShift Build is triggered, please provide either of the following parameter set" 
+        msg:
+          - "No OpenShift Build is triggered, please provide either of the following parameter set"
           - "(webhook_url, webhook_secret)"
           - "(cluster, namespace, buildConfigName, webhook_secret)"
       when:
           - webhook_url is not defined
           - (namespace is not defined) or (buildConfigName is not defined)
+
+    - name: Show response content 
+      debug:
+        var: response_content
+
+    - name: Get image name tag
+      debug:
+        msg: "{{ response_content.json.spec.output.to.name }}"
+      register: image_name_tag
+    
+    - name: Get image name
+      debug:
+        msg: "{{ response_content.json.metadata.labels.buildconfig }}"
+      register: image_name
+
+    - name: wait until build finish
+      command: oc describe build/{{ response_content.json.metadata.name }}
+      register: curr_status
+      retries: 60 
+      delay: 10 
+      until:
+        - curr_status.stdout_lines[12] is search ("Complete") 
+
+    - name: "make sure we use thoth-infra-stage for ThothOps"
+      command: oc project thoth-infra-stage
+
+    - name: "make sure thoth-ops is allowed to pull the ImageStreamTags from thoth-test-core"
+      command: oc policy add-role-to-user
+        system:image-puller system:serviceaccount:thoth-infra-stage:default \
+        --namespace=thoth-test-core
+
+    - name: "delete thoth-ops Pod"
+      k8s_raw:
+        state: absent
+        definition:
+          kind: Pod
+          metadata:
+            namespace: thoth-infra-stage
+            name: thoth-ops
+
+    - pause:
+        seconds: 12
+
+    - name: "create thoth-ops Pod"
+      k8s_raw:
+        state: present
+        definition:
+          kind: Pod
+          apiVersion: v1
+          metadata:
+            namespace: thoth-infra-stage
+            name: thoth-ops
+            labels:
+              playbook: push_test_to_quayio
+          spec:
+            servcieAccountName: "thoth-ops"
+            containers:
+              - image: "thoth-ops:{{ thoth_ops_version }}"
+                imagePullPolicy: IfNotPresent
+                name: thoth-ops
+                resources: {}
+                stdin: true
+                stdinOnce: true
+                tty: true
+            restartPolicy: Never
+            resources:
+              limits:
+                cpu: 500m
+                memory: 600Mi
+              requests:
+                cpu: 200m
+                memory: 200Mi
+      ignore_errors: true
+
+    - name: "wait for thoth-ops pod to be ready"
+      k8s_facts:
+        kind: Pod
+        name: thoth-ops
+        namespace: thoth-infra-stage
+        field_selectors:
+          - status.phase = running
+      register: thoth_ops_pod
+      retries: 10
+      delay: 5
+      until:
+        - thoth_ops_pod.resources[0]['status']['phase'] == "Running"
+
+    - name: "push test ImageStreamTags"
+      command: oc rsh thoth-ops skopeo copy \
+        --dest-creds=thoth-station+thoth_pusher:{{ quay_secret.key }} \
+        --src-tls-verify=false \
+        --src-creds=serviceaccount:{{ thoth_registry_secret.key }} \
+        docker://docker-registry.default.svc:5000/thoth-test-core/{{ image_name_tag.msg }} \
+        docker://quay.io/thoth-station/{{ image_name.msg }}:{{ image_stream_tag }}
+
+    - name: "delete thoth-ops Pod"
+      k8s_raw:
+        state: absent
+        definition:
+          kind: Pod
+          apiVersion: v1
+          metadata:
+            namespace: thoth-infra-stage
+            name: thoth-ops
+
+    - name: "import tag to infra project"
+      shell: oc tag --namespace "thoth-infra-stage" \
+        --source=docker "quay.io/thoth-station/{{ image_name.msg }}:{{ image_stream_tag }}" \
+        "{{ image_name }}:latest"

--- a/zuul.d/quayio_secret.yaml
+++ b/zuul.d/quayio_secret.yaml
@@ -1,0 +1,15 @@
+---
+- secret:
+    name: quayio_thoth_pusher_acccess_token_secret
+    data:
+      key: !encrypted/pkcs1-oaep
+        - MTa2/ey2GjVn/EpfY0OjpqukyI3s65gSyA6adGhiI46TPawTQtFmovZusZiUFVGddGbFk
+          z90t6ENEoXtWpSg9uVoMByjbNFaPBsnH5xaF0LBVlWiENlDPCpdAVODYGjzzjonZq8ojG
+          wy8xkLdI5kgkpvQQDXg1DnfQ4JisaLYGxQ4mWv4Ntg+myqSjHLp+CdJN2IhIwb/QreGyc
+          RsQvQRilsiL2IR/9r5adoG4IXqd/XslOcWPMxhBOwi5AhDtcmefzCy8bqBaMThANU5YGH
+          U1GQkBqrrr+Wn++FFmAXpVcMPF06dDNkLSMqTph3L+eHMxzOei/MzlNvq69kIm1YTRS5Y
+          Yo/Hb5z3Nn02TFmJA/wOVUmTS/Synd0alrepULBV+Zwbf0jdCCBlZUSLBuUGI13BKSaEG
+          VZ6wtROAhOT66PsgknKVUnkjZDNDC0e15NTWwqBz0Nks0KnHnkYCH6h61nVV6buELrODY
+          +BfSe5mb09nFi1Od+bzlFKoiiq7htQhup0yhmDxfjA4NmAFJkvOaWILljPNGjrbnQjFF9
+          Xz+rbqPvWkYGBssLLy2nRG55kYJPywtilNZ8fxj4oiHwCaNUS18UEfbPJTV4DZwShAwpo
+          tUoxNcKjNhlQ9YuniKg8Zd7alGl6Z5isWp8aw8SKZM3MBHlLP4ISQlay7F+EGI=

--- a/zuul.d/thoth-openshift.yaml
+++ b/zuul.d/thoth-openshift.yaml
@@ -27,6 +27,10 @@
     secrets:
       - name: webhook_secret
         secret: sesheta_webhooks_generic_webhook_secret
+      - name: quay_secret
+        secret: quayio_thoth_pusher_acccess_token_secret
+      - name: thoth_registry_secret
+        secret: thoth_test_core_registry_access_token_secret
 
 - job:
     name: "thoth-github-wip"

--- a/zuul.d/thoth_registry_secret.yaml
+++ b/zuul.d/thoth_registry_secret.yaml
@@ -1,0 +1,15 @@
+---
+- secret:
+    name: thoth_test_core_registry_access_token_secret 
+    data:
+      key: !encrypted/pkcs1-oaep
+        - 3YehXmtNCbTCminqTW/8eT+6/AGCnKZ3SX2UTqkEO2HMdK44wvUOKqN3eAV4UGoC/J7yp
+          I5fnxzffGv6lEnpL7UAajk9yEclY/R7kgNOWgzZUkFaC6p08E7yrx8n5TPUyVXFFRUzsN
+          O/1a9MObgihlC4n8c9iE961PC+p7d0VC1WDFDXt9fEAsxoyhYbCXLdivrgL60Ubexj/iX
+          lBqWT3iAmyIp3eb49ayZPwVid86esYAS/qsz/tDTSdl3dwhADHUbQ03Mn5lQcNZ6xnSYl
+          UzVlzmow5RzGbuxFJQ6SZBeo4QUtqsaG/bVHuH0Rnm/uHjwFjakOMLo709bYExOy+K5vT
+          OvJNIRsqH5jbAQ8R+j0OTTxa7lPGtyC9LbMGpjQSS6oWN2pDFX4wSf1cSnZddGRet2ezR
+          9etWWyFqB5nX1UCzY1L4vgAJiVDsu+VOKo0OWLLMwW++kALTF3ymh748ZjzTsvnnbSXfO
+          He1hMxboe8kapNPx7OueEEte6lwapxpiDF1eSD1DnYcthGhpOI5SXKiIYPxcO3UB5jPV0
+          lZBOrXWQ6qf99ZaELDyOz2inrQNygktH2RMSV2Y1qDT4Klw+qGvrlXl9k8dOIEXUm7Ffs
+          AhXWqFxSHh8JJQJCUpeRChKjYgBUaZmB1G6Ar7F06hNLCgAzj76qxWBfax34IE=


### PR DESCRIPTION
Adding the feature that this job will push the image to `quay.io` once the image build is finished, and then another `ImageStreamTag` is created in `thoth-infra-stage` referring to the `quay.io` image.

Two secrets for accessing `quay.io` and thoth internal registry are created using the encryption script in zuul [source code](https://opendev.org/zuul/zuul/src/branch/master/tools/encrypt_secret.py) that is able to encrypt the secret using zuul public key. The secrets can be decrypted and use by zuul server later and parse to the job.
Here is the script for the encryption
```
python3 encrypt_secret.py --insecure --tenant local https://managesf.thoth-station.ninja/zuul/ thoth-station/zuul-config --strip --infile secret.txt
```

The extra job taking the `webhook_url` job is removed, since all `BuildConfig` are updated using the new API version.

The job will wait for the build process to finish with maximum 600 seconds (10 mins), normally, a build cost 3 to 5 mins.

Haven't been fully tested, because because I don't have access to the `thoth-infra-stage` namespace.
