### PR TITLE
Update upstream zuul-jobs to the new url

### DIFF
--- a/resources/_internal.yaml
+++ b/resources/_internal.yaml
@@ -13,8 +13,8 @@ resources:
       type: github
       github-app-name: thoth-zuul
       github-label: approved
-    git.zuul-ci.org:
-      base-url: "https://git.zuul-ci.org"
+    opendev.org:
+      base-url: "https://opendev.org"
       type: git
 
   projects:
@@ -25,7 +25,7 @@ resources:
         - thoth-station/zuul-config:
             zuul/config-project: True
         - thoth-station/zuul-jobs
-        - zuul-jobs:
-            connection: git.zuul-ci.org
+        - zuul/zuul-jobs:
+            connection: opendev.org
             zuul/include: [job]
             zuul/shadow: thoth-station/zuul-jobs

--- a/zuul.d/_jobs-base.yaml
+++ b/zuul.d/_jobs-base.yaml
@@ -8,8 +8,8 @@
     post-run:
       - playbooks/base/post.yaml
     roles:
-      - zuul: thoth-station/zuul-jobs
-      - zuul: zuul-jobs
+      - zuul: github.com/thoth-station/zuul-jobs
+      - zuul: opendev.org/zuul/zuul-jobs
     timeout: 1800
     attempts: 3
     secrets:

--- a/zuul.d/_jobs-openshift.yaml
+++ b/zuul.d/_jobs-openshift.yaml
@@ -11,8 +11,8 @@
     post-run:
       - playbooks/base/post.yaml
     roles:
-      - zuul: thoth-station/zuul-jobs
-      - zuul: zuul-jobs
+      - zuul: github.com/thoth-station/zuul-jobs
+      - zuul: opendev.org/zuul/zuul-jobs
     timeout: 1800
     # Set attempts to 1 until it's working well
     attempts: 1
@@ -35,8 +35,8 @@
     post-run:
       - playbooks/base/post.yaml
     roles:
-      - zuul: thoth-station/zuul-jobs
-      - zuul: zuul-jobs
+      - zuul: github.com/thoth-station/zuul-jobs
+      - zuul: opendev.org/zuul/zuul-jobs
     # Set attempts to 1 until it's working well
     attempts: 1
     secrets:

--- a/zuul.d/thoth-openshift.yaml
+++ b/zuul.d/thoth-openshift.yaml
@@ -7,8 +7,8 @@
     post-run:
       - playbooks/base/post.yaml
     roles:
-      - zuul: thoth-station/zuul-test-jobs
-      - zuul: zuul-jobs
+      - zuul: github.com/thoth-station/zuul-test-jobs
+      - zuul: opendev.org/zuul/zuul-jobs
     timeout: 1800
     # Set attempts to 1 until it's working well
     attempts: 1
@@ -33,7 +33,7 @@
     parent: "base-openshift-pod"
     description: |
       This job calls the github-wip playbook with a curated set of
-      WIP labels and WIP title keywords. It fails if the PR is 
+      WIP labels and WIP title keywords. It fails if the PR is
       work in progress.
     run: "playbooks/github-wip/run.yaml"
     nodeset:


### PR DESCRIPTION
This change also adds the connection name to the roles attribute
to avoid confusion.