### PR TITLE
Included prefix v for the tag

### DIFF
--- a/zuul.d/_pipelines.yaml
+++ b/zuul.d/_pipelines.yaml
@@ -143,7 +143,7 @@
     trigger:
       github.com:
         - event: push
-          ref: ^refs/tags/([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z.-]+))?(?:\+([0-9a-zA-Z.-]+))?$
+          ref: ^refs/tags/v([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z.-]+))?(?:\+([0-9a-zA-Z.-]+))?$
     success:
       sqlreporter:
     failure:


### PR DESCRIPTION
Related-to: https://github.com/AICoE/Sefkhet-Abwy/pull/33

Publishing of module to PyPI is being interrupted as the prefix **v** as added to projects tags, with the fix include in this PR would resolve the issue. 

storage pypi release was interrupted: 
https://github.com/thoth-station/storages/releases/tag/v0.22.12 

Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>